### PR TITLE
update container default horizontal style to display as grid

### DIFF
--- a/packages/react/src/components/UI/Container.tsx
+++ b/packages/react/src/components/UI/Container.tsx
@@ -1,6 +1,5 @@
 import { css } from '@stitches/core'
 import { generateClassNames } from '../../../common/theming'
-import { CLASS_NAMES, PREPENDED_CLASS_NAMES } from '../../constants'
 import { Appearance } from '../../types'
 
 const containerDefaultStyles = css({
@@ -9,8 +8,8 @@ const containerDefaultStyles = css({
   variants: {
     direction: {
       horizontal: {
-        flexDirection: 'row',
-        margin: '4px 0',
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fit, minmax(48px, 1fr))',
       },
       vertical: {
         flexDirection: 'column',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix that closes #40 

## What is the new behavior?

Updated container horizontal style to display grid instead of flex.

## Additional context

With 2 Social Auth (fills the whole row)

<img width="397" alt="image" src="https://user-images.githubusercontent.com/35736525/193980319-562e8c78-cda9-4f4d-ab2f-54d62262e4c8.png">

With 5 Social Auth (fills the whole row)
<img width="356" alt="image" src="https://user-images.githubusercontent.com/35736525/193980590-09291ef1-92bb-4117-a0f9-33e6cab26750.png">

With many social auth spanning more than a row

<img width="361" alt="image" src="https://user-images.githubusercontent.com/35736525/193980680-d49c2b75-6f34-454d-8832-312438d4e139.png">

With all social auth

<img width="382" alt="image" src="https://user-images.githubusercontent.com/35736525/193980464-5ae5d1ee-afa6-471a-a3c5-a9a433e55f8a.png">

P.S. would be nice if this can get the `hacktoberfest-accepted` label later on
