### PR TITLE
fix: removed doubled button border radius

### DIFF
--- a/packages/react/common/theming/Themes.tsx
+++ b/packages/react/common/theming/Themes.tsx
@@ -68,7 +68,6 @@ const supabase: ThemeVariables = {
   },
   // borderStyles: {},
   radii: {
-    borderRadiusButton: '4px',
     buttonBorderRadius: '4px',
     inputBorderRadius: '4px',
   },

--- a/packages/react/common/theming/Types.tsx
+++ b/packages/react/common/theming/Types.tsx
@@ -48,7 +48,6 @@ export type ThemeVariables = {
     inputBorderWidth?: string
   }
   radii?: {
-    borderRadiusButton?: string
     buttonBorderRadius?: string
     inputBorderRadius?: string
   }

--- a/packages/react/common/theming/defaultThemes.ts
+++ b/packages/react/common/theming/defaultThemes.ts
@@ -69,7 +69,6 @@ export const ThemeSupa: Theme = {
     },
     // borderStyles: {},
     radii: {
-      borderRadiusButton: '4px',
       buttonBorderRadius: '4px',
       inputBorderRadius: '4px',
     },

--- a/packages/react/src/components/UI/Button.tsx
+++ b/packages/react/src/components/UI/Button.tsx
@@ -8,7 +8,7 @@ const buttonDefaultStyles = css({
   alignItems: 'center',
   justifyContent: 'center',
   gap: '8px',
-  borderRadius: '$borderRadiusButton',
+  borderRadius: '$buttonBorderRadius',
   fontSize: '$baseButtonSize',
   padding: '$buttonPadding',
   cursor: 'pointer',


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix 

## What is the current behavior?

There are two properties for specifying the border radius for the button.`borderRadiusButton` is working and `buttonBorderRadius` is not applying any styles.

## What is the new behavior?

The property `borderRadiusButton` was renamed to `buttonBorderRadius` for making it consistent to `inputBorderRadius`. Now `buttonBorderRadius` is working in the expected way.

## Additional context

Add any other context or screenshots.
