### PR TITLE
fix: fixed sign in classes not applied

### DIFF
--- a/packages/react/src/components/Auth/Auth.tsx
+++ b/packages/react/src/components/Auth/Auth.tsx
@@ -165,7 +165,11 @@ function Auth({
     case VIEWS.SIGN_IN:
       return (
         <Container>
-          <EmailAuth {...emailProp} authView={'sign_in'} />
+          <EmailAuth
+            {...emailProp}
+            appearance={appearance}
+            authView={'sign_in'}
+          />
         </Container>
       )
     case VIEWS.SIGN_UP:


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

When passing a class in the `appearance` property it will be applied to all views except to `sign_in`. For example, when passing the font-bold from tailwind to `className.button` it will be applied to `sign_up` or `forgotten_password` view, but not to `sign_in` view.

## What is the new behavior?

The classes passed in property `className` in `appearance` will be applied to `sign_in` view.

## Additional context

Add any other context or screenshots.
