### PR TITLE
fixes class names not propagating to email auth components

### DIFF
--- a/.changeset/cyan-camels-report.md
+++ b/.changeset/cyan-camels-report.md
@@ -1,0 +1,5 @@
+---
+'@supabase/auth-ui-react': patch
+---
+
+fix class names not propagating to email auth components

--- a/.changeset/violet-camels-live.md
+++ b/.changeset/violet-camels-live.md
@@ -1,0 +1,5 @@
+---
+'@supabase/auth-ui-react': patch
+---
+
+Remove just-merge and add merge function inline

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -35,7 +35,6 @@
   "dependencies": {
     "@stitches/core": "^1.2.8",
     "@stitches/react": "^1.2.8",
-    "just-merge": "^3.1.1",
     "prop-types": "^15.7.2"
   },
   "devDependencies": {

--- a/packages/react/src/components/Auth/Auth.stories.tsx
+++ b/packages/react/src/components/Auth/Auth.stories.tsx
@@ -120,6 +120,27 @@ export const magicLink = (args: any) => (
   </Container>
 )
 
+export const withCustomClassNames = (args: any) => (
+  <Container {...args}>
+    <Auth
+      {...args}
+      dark={useDarkMode() ? true : false}
+      appearance={{
+        className: {
+          input: 'foo',
+          anchor: 'foo',
+          button: 'foo',
+          container: 'foo',
+          divider: 'foo',
+          label: 'foo',
+          loader: 'foo',
+          message: 'foo',
+        },
+      }}
+    />
+  </Container>
+)
+
 export const ChangeViewState = (args: any) => {
   const [view, setView] = useState<
     'sign_in' | 'sign_up' | 'forgotten_password' | 'magic_link'
@@ -167,7 +188,11 @@ export const ChangeViewState = (args: any) => {
       </div>
       <Auth.UserContextProvider supabaseClient={supabase}>
         <Container supabaseClient={supabase}>
-          <Auth supabaseClient={supabase} view={view} />
+          <Auth
+            supabaseClient={supabase}
+            view={view}
+            appearance={{ className: { input: 'foo' } }}
+          />
         </Container>
       </Auth.UserContextProvider>
     </div>

--- a/packages/react/src/components/Auth/Auth.stories.tsx
+++ b/packages/react/src/components/Auth/Auth.stories.tsx
@@ -188,11 +188,7 @@ export const ChangeViewState = (args: any) => {
       </div>
       <Auth.UserContextProvider supabaseClient={supabase}>
         <Container supabaseClient={supabase}>
-          <Auth
-            supabaseClient={supabase}
-            view={view}
-            appearance={{ className: { input: 'foo' } }}
-          />
+          <Auth supabaseClient={supabase} view={view} />
         </Container>
       </Auth.UserContextProvider>
     </div>

--- a/packages/react/src/components/Auth/Auth.tsx
+++ b/packages/react/src/components/Auth/Auth.tsx
@@ -155,6 +155,7 @@ function Auth({
     magicLink,
     showLinks,
     i18n,
+    appearance,
   }
 
   /**

--- a/packages/react/src/components/Auth/Auth.tsx
+++ b/packages/react/src/components/Auth/Auth.tsx
@@ -1,5 +1,5 @@
 import { createStitches, createTheme } from '@stitches/core'
-import merge from 'just-merge'
+import { merge } from '../../utils'
 import React, { useEffect, useState } from 'react'
 import { Auth as AuthProps, Localization, I18nVariables } from '../../types'
 import { VIEWS } from './../../constants'

--- a/packages/react/src/utils.ts
+++ b/packages/react/src/utils.ts
@@ -1,0 +1,24 @@
+function value(src: any, next: any) {
+  let k
+  if (src && next && typeof src === 'object' && typeof next === 'object') {
+    if (Array.isArray(next)) {
+      for (k = 0; k < next.length; k++) {
+        src[k] = value(src[k], next[k])
+      }
+    } else {
+      for (k in next) {
+        src[k] = value(src[k], next[k])
+      }
+    }
+    return src
+  }
+  return next
+}
+
+export function merge(target: any, ...args: any) {
+  let len: number = args.length
+  for (let i = 0; i < len; i++) {
+    target = value(target, args[i])
+  }
+  return target
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,7 +58,6 @@ importers:
       eslint-config-prettier: ^6.12.0
       eslint-plugin-prettier: ^3.1.4
       fsevents: ^2.3.2
-      just-merge: ^3.1.1
       npm-run-all: ^4.1.5
       prettier: ^2.1.2
       prop-types: ^15.7.2
@@ -84,7 +83,6 @@ importers:
     dependencies:
       '@stitches/core': 1.2.8
       '@stitches/react': 1.2.8_react@17.0.2
-      just-merge: 3.1.1
       prop-types: 15.8.1
     optionalDependencies:
       fsevents: 2.3.2
@@ -5778,6 +5776,7 @@ packages:
 
   /bindings/1.5.0:
     resolution: {integrity: sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==}
+    requiresBuild: true
     dependencies:
       file-uri-to-path: 1.0.0
     dev: true
@@ -8795,6 +8794,7 @@ packages:
 
   /file-uri-to-path/1.0.0:
     resolution: {integrity: sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==}
+    requiresBuild: true
     dev: true
     optional: true
 
@@ -11382,10 +11382,6 @@ packages:
     engines: {node: '>=8'}
     dev: true
 
-  /just-merge/3.1.1:
-    resolution: {integrity: sha512-q0VS9owVgV9BcD2cy+E8MB8sIYpqmGAhoAGHH2PHtGwkC0CoITB8FJPMTg38GDO20cuaEGsR8SxCb+kf+g3G2Q==}
-    dev: false
-
   /killable/1.0.1:
     resolution: {integrity: sha512-LzqtLKlUwirEUyl/nicirVmNiPvYs7l5n8wOPP7fyJVpUPkvCnW/vuiXGpylGUlnPDnB7311rARzAt3Mhswpjg==}
     dev: true
@@ -12323,6 +12319,7 @@ packages:
 
   /nan/2.16.0:
     resolution: {integrity: sha512-UdAqHyFngu7TfQKsCBgAA6pWDkT8MAO7d0jyOecVhN5354xbLqdn8mV9Tat9gepAupm0bt2DbeaSC8vS52MuFA==}
+    requiresBuild: true
     dev: true
     optional: true
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix #66

## What is the current behavior?

(see #66) - class names are not applied to email components

## What is the new behavior?

Class names properly applied.

See the new storybook story:

![Screen Shot 2022-11-07 at 4 05 57 PM](https://user-images.githubusercontent.com/3788405/200434291-25a5bff0-c48b-41ba-8290-e4b83c057b4f.png)

## Additional context

I added a story to storybook to demonstrate proper class propagation. I couldn't figure out how to add tests here, but would be nice to have for this case in particular.
