### PR TITLE
feat: add id_formal and id_informal localizations

### DIFF
--- a/packages/react/common/lib/Localization/id_formal.json
+++ b/packages/react/common/lib/Localization/id_formal.json
@@ -1,0 +1,38 @@
+{
+  "sign_up": {
+    "email_label": "Alamat Surel",
+    "password_label": "Buat Sebuah Kata Sandi",
+    "email_input_placeholder": "Alamat Surel Anda",
+    "password_input_placeholder": "Kata Sandi Anda",
+    "button_label": "Mendaftar",
+    "social_provider_text": "Masuk dengan",
+    "link_text": "Belum punya akun? Mendaftar"
+  },
+  "sign_in": {
+    "email_label": "Alamat Email",
+    "password_label": "Kata Sandi Anda",
+    "email_input_placeholder": "Alamat Surel Anda",
+    "password_input_placeholder": "Kata Sandi Anda",
+    "button_label": "Masuk",
+    "social_provider_text": "Masuk dengan",
+    "link_text": "Sudah punya akun? Masuk"
+  },
+  "magic_link": {
+    "email_input_label": "Alamat Email",
+    "email_input_placeholder": "Alamat Surel Anda",
+    "button_label": "Kirim Tautan Ajaib",
+    "link_text": "Kirim sebuah surel berisi tautan ajaib"
+  },
+  "forgotten_password": {
+    "email_label": "Alamat Email",
+    "password_label": "Kata Sandi Anda",
+    "email_input_placeholder": "Alamat Surel Anda",
+    "button_label": "Kirim instruksi atur ulang kata sandi",
+    "link_text": "Lupa Kata Sandi Anda?"
+  },
+  "update_password": {
+    "password_label": "Kata sandi baru",
+    "password_input_placeholder": "Kata sandi baru Anda",
+    "button_label": "Perbarui kata sandi"
+  }
+}

--- a/packages/react/common/lib/Localization/id_informal.json
+++ b/packages/react/common/lib/Localization/id_informal.json
@@ -1,0 +1,38 @@
+{
+  "sign_up": {
+    "email_label": "Alamat Email",
+    "password_label": "Buat Sebuah Password",
+    "email_input_placeholder": "Alamat Email Kamu",
+    "password_input_placeholder": "Password Kamu",
+    "button_label": "Buat Akun",
+    "social_provider_text": "Masuk dengan",
+    "link_text": "Belum punya akun? Mendaftar"
+  },
+  "sign_in": {
+    "email_label": "Alamat Email",
+    "password_label": "Password Kamu",
+    "email_input_placeholder": "Alamat Email Kamu",
+    "password_input_placeholder": "Password Kamu",
+    "button_label": "Masuk",
+    "social_provider_text": "Masuk dengan",
+    "link_text": "Sudah punya akun? Masuk"
+  },
+  "magic_link": {
+    "email_input_label": "Alamat Email",
+    "email_input_placeholder": "Alamat Email Kamu",
+    "button_label": "Kirim Magic Link",
+    "link_text": "Kirim sebuah email berisi magic link"
+  },
+  "forgotten_password": {
+    "email_label": "Alamat Email",
+    "password_label": "Password Kamu",
+    "email_input_placeholder": "Alamat Email Kamu",
+    "button_label": "Kirim instruksi reset password",
+    "link_text": "Lupa Password Kamu?"
+  },
+  "update_password": {
+    "password_label": "Kata sandi baru",
+    "password_input_placeholder": "Password baru Kamu",
+    "button_label": "Perbarui password"
+  }
+}

--- a/packages/react/common/lib/Localization/index.ts
+++ b/packages/react/common/lib/Localization/index.ts
@@ -1,4 +1,6 @@
 export { default as de_formal } from './de_formal.json'
 export { default as de_informal } from './de_informal.json'
 export { default as en } from './en.json'
+export { default as id_formal } from './id_formal.json'
+export { default as id_informal } from './id_informal.json'
 export { default as ja } from './ja.json'

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -18,6 +18,8 @@ export interface Localization {
   ['ja']: I18nVariables
   ['de_formal']: I18nVariables
   ['de_informal']: I18nVariables
+  ['id_formal']: I18nVariables
+  ['id_informal']: I18nVariables
 }
 
 export type SocialLayout = 'horizontal' | 'vertical'


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature

## What is the current behavior?

No Indonesian (Bahasa) translation

## What is the new behavior?

Adds formal and informal translations for Bahasa.

## Additional context

Some word in Bahasa has various terms. Example: "you" in Bahasa: 

- Formal: "Anda"
- Informal: "Kamu"

**Reference:**

- https://en.wiktionary.org/wiki/Category:Indonesian_pronouns
- https://www.quora.com/How-does-spoken-Indonesian-differ-from-formal-Indonesian-and-is-Bahasa-Gaul-and-Bahasa-Jakarta-the-same
