### PR TITLE
fix: svg icons attribute names

### DIFF
--- a/.changeset/tall-chairs-reply.md
+++ b/.changeset/tall-chairs-reply.md
@@ -1,0 +1,5 @@
+---
+'@supabase/auth-ui-react': patch
+---
+
+Fix svg icons attribute names

--- a/packages/react/src/components/Auth/Icons.tsx
+++ b/packages/react/src/components/Auth/Icons.tsx
@@ -126,8 +126,8 @@ export const bitbucket = () => (
         y2="54.48"
         gradientUnits="userSpaceOnUse"
       >
-        <stop offset="0.18" stop-color="#0052cc" />
-        <stop offset="1" stop-color="#2684ff" />
+        <stop offset="0.18" stopColor="#0052cc" />
+        <stop offset="1" stopColor="#2684ff" />
       </linearGradient>
     </defs>
     <title>Bitbucket-blue</title>
@@ -178,8 +178,8 @@ export const azure = () => (
       gradientTransform="translate(1981.75 -1362.063) scale(1.5625)"
       gradientUnits="userSpaceOnUse"
     >
-      <stop offset="0" stop-color="#114a8b" />
-      <stop offset="1" stop-color="#0669bc" />
+      <stop offset="0" stopColor="#114a8b" />
+      <stop offset="1" stopColor="#0669bc" />
     </linearGradient>
     <path
       fill="url(#k8yl7~hDat~FaoWq8WjN6a)"
@@ -198,11 +198,11 @@ export const azure = () => (
       gradientTransform="translate(1981.75 -1362.063) scale(1.5625)"
       gradientUnits="userSpaceOnUse"
     >
-      <stop offset="0" stop-opacity=".3" />
-      <stop offset=".071" stop-opacity=".2" />
-      <stop offset=".321" stop-opacity=".1" />
-      <stop offset=".623" stop-opacity=".05" />
-      <stop offset="1" stop-opacity="0" />
+      <stop offset="0" stopOpacity=".3" />
+      <stop offset=".071" stopOpacity=".2" />
+      <stop offset=".321" stopOpacity=".1" />
+      <stop offset=".623" stopOpacity=".05" />
+      <stop offset="1" stopOpacity="0" />
     </linearGradient>
     <path
       fill="url(#k8yl7~hDat~FaoWq8WjN6b)"
@@ -217,8 +217,8 @@ export const azure = () => (
       gradientTransform="translate(1981.75 -1362.063) scale(1.5625)"
       gradientUnits="userSpaceOnUse"
     >
-      <stop offset="0" stop-color="#3ccbf4" />
-      <stop offset="1" stop-color="#2892df" />
+      <stop offset="0" stopColor="#3ccbf4" />
+      <stop offset="1" stopColor="#2892df" />
     </linearGradient>
     <path
       fill="url(#k8yl7~hDat~FaoWq8WjN6c)"
@@ -269,26 +269,26 @@ export const notion = () => (
     viewBox="0 0 48 48"
     width="512px"
     height="512px"
-    fill-rule="evenodd"
-    clip-rule="evenodd"
+    fillRule="evenodd"
+    clipRule="evenodd"
   >
     <path
       fill="#fff"
-      fill-rule="evenodd"
+      fillRule="evenodd"
       d="M11.553,11.099c1.232,1.001,1.694,0.925,4.008,0.77 l21.812-1.31c0.463,0,0.078-0.461-0.076-0.538l-3.622-2.619c-0.694-0.539-1.619-1.156-3.391-1.002l-21.12,1.54 c-0.77,0.076-0.924,0.461-0.617,0.77L11.553,11.099z"
-      clip-rule="evenodd"
+      clipRule="evenodd"
     />
     <path
       fill="#fff"
-      fill-rule="evenodd"
+      fillRule="evenodd"
       d="M12.862,16.182v22.95c0,1.233,0.616,1.695,2.004,1.619 l23.971-1.387c1.388-0.076,1.543-0.925,1.543-1.927V14.641c0-1-0.385-1.54-1.234-1.463l-25.05,1.463 C13.171,14.718,12.862,15.181,12.862,16.182L12.862,16.182z"
-      clip-rule="evenodd"
+      clipRule="evenodd"
     />
     <path
       fill="#424242"
-      fill-rule="evenodd"
+      fillRule="evenodd"
       d="M11.553,11.099c1.232,1.001,1.694,0.925,4.008,0.77 l21.812-1.31c0.463,0,0.078-0.461-0.076-0.538l-3.622-2.619c-0.694-0.539-1.619-1.156-3.391-1.002l-21.12,1.54 c-0.77,0.076-0.924,0.461-0.617,0.77L11.553,11.099z M12.862,16.182v22.95c0,1.233,0.616,1.695,2.004,1.619l23.971-1.387 c1.388-0.076,1.543-0.925,1.543-1.927V14.641c0-1-0.385-1.54-1.234-1.463l-25.05,1.463C13.171,14.718,12.862,15.181,12.862,16.182 L12.862,16.182z M36.526,17.413c0.154,0.694,0,1.387-0.695,1.465l-1.155,0.23v16.943c-1.003,0.539-1.928,0.847-2.698,0.847 c-1.234,0-1.543-0.385-2.467-1.54l-7.555-11.86v11.475l2.391,0.539c0,0,0,1.386-1.929,1.386l-5.317,0.308 c-0.154-0.308,0-1.078,0.539-1.232l1.388-0.385V20.418l-1.927-0.154c-0.155-0.694,0.23-1.694,1.31-1.772l5.704-0.385l7.862,12.015 V19.493l-2.005-0.23c-0.154-0.848,0.462-1.464,1.233-1.54L36.526,17.413z M7.389,5.862l21.968-1.618 c2.698-0.231,3.392-0.076,5.087,1.155l7.013,4.929C42.614,11.176,43,11.407,43,12.33v27.032c0,1.694-0.617,2.696-2.775,2.849 l-25.512,1.541c-1.62,0.077-2.391-0.154-3.239-1.232l-5.164-6.7C5.385,34.587,5,33.664,5,32.585V8.556 C5,7.171,5.617,6.015,7.389,5.862z"
-      clip-rule="evenodd"
+      clipRule="evenodd"
     />
   </svg>
 )


### PR DESCRIPTION
Change occurences of the 'clip-rule', 'fill-rule', 'stop-color', 'stop-opacity' SVG attributes to camel-case.

## What kind of change does this PR introduce?

Bug fix. See issue #74.

## What is the current behavior?

Some SVG element attributes in [Icons.tsx](https://github.com/supabase/auth-ui/blob/main/packages/react/src/components/Auth/Icons.tsx) are not camel-cased, as [specified by React](https://reactjs.org/docs/dom-elements.html).

## What is the new behavior?

All occurences of the `clip-rule`, `fill-rule`, `stop-color` and `stop-opacity` attributes within [Icons.tsx](https://github.com/supabase/auth-ui/blob/main/packages/react/src/components/Auth/Icons.tsx) have been changed to camel-case.