### PR TITLE
Fix: EmailAuth mounted ref not resetting during remount

### DIFF
--- a/packages/react/src/components/Auth/interfaces/EmailAuth.tsx
+++ b/packages/react/src/components/Auth/interfaces/EmailAuth.tsx
@@ -56,6 +56,7 @@ function EmailAuth({
   const [message, setMessage] = useState('')
 
   useEffect(() => {
+    isMounted.current = true
     setEmail(defaultEmail)
     setPassword(defaultPassword)
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes #79.

When running React 18+ in Strict mode during dev, the component will "mount, unmount, then remount again" in order to ensure components have reusable state ([read more](https://reactjs.org/docs/strict-mode.html#ensuring-reusable-state)).

Because of this behaviour and the fact the `isMounted` ref is not set to reset in the component's `useEffect`, the flag is permanently set to false under certain circumstances. See the issue for more info.

## What is the current behavior?

The `isMounted` ref is set to false immediately on mount because of the effect of strict mode.

## What is the new behavior?

The `isMounted` ref is correctly reset back to true whenever the component is remounted or the `authView` changes.

