### PR TITLE
Feature: UI loading state feedback

### DIFF
--- a/.changeset/few-toes-ring.md
+++ b/.changeset/few-toes-ring.md
@@ -1,0 +1,5 @@
+---
+'@supabase/auth-ui-react': patch
+---
+
+Add UI loading state feedback to EmailAuth

--- a/packages/react/common/lib/Localization/en.json
+++ b/packages/react/common/lib/Localization/en.json
@@ -5,6 +5,7 @@
     "email_input_placeholder": "Your email address",
     "password_input_placeholder": "Your password",
     "button_label": "Sign up",
+    "loading_button_label": "Signing up ...",
     "social_provider_text": "Sign in with",
     "link_text": "Don't have an account? Sign up"
   },
@@ -14,6 +15,7 @@
     "email_input_placeholder": "Your email address",
     "password_input_placeholder": "Your password",
     "button_label": "Sign in",
+    "loading_button_label": "Signing in ...",
     "social_provider_text": "Sign in with",
     "link_text": "Already have an account? Sign in"
   },

--- a/packages/react/src/components/Auth/interfaces/EmailAuth.tsx
+++ b/packages/react/src/components/Auth/interfaces/EmailAuth.tsx
@@ -105,6 +105,8 @@ function EmailAuth({
     setAuthView(newView)
   }
 
+  const labels = i18n?.[authView]
+
   return (
     <form
       id={authView === 'sign_in' ? `auth-sign-in` : `auth-sign-up`}
@@ -116,12 +118,12 @@ function EmailAuth({
         <Container direction="vertical" gap="large" appearance={appearance}>
           <div>
             <Label htmlFor="email" appearance={appearance}>
-              {i18n?.[authView]?.email_label}
+              {labels?.email_label}
             </Label>
             <Input
               type="email"
               name="email"
-              placeholder={i18n?.[authView]?.email_input_placeholder}
+              placeholder={labels?.email_input_placeholder}
               defaultValue={email}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                 setEmail(e.target.value)
@@ -132,12 +134,12 @@ function EmailAuth({
           </div>
           <div>
             <Label htmlFor="password" appearance={appearance}>
-              {i18n?.[authView]?.password_label}
+              {labels?.password_label}
             </Label>
             <Input
               type="password"
               name="password"
-              placeholder={i18n?.[authView]?.password_input_placeholder}
+              placeholder={labels?.password_input_placeholder}
               defaultValue={password}
               onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
                 setPassword(e.target.value)
@@ -156,7 +158,7 @@ function EmailAuth({
           loading={loading}
           appearance={appearance}
         >
-          {i18n?.[authView]?.button_label}
+          {loading ? labels?.loading_button_label : labels?.button_label}
         </Button>
 
         {showLinks && (

--- a/packages/react/src/components/UI/Button.tsx
+++ b/packages/react/src/components/UI/Button.tsx
@@ -19,22 +19,26 @@ const buttonDefaultStyles = css({
   transitionPproperty: 'background-color',
   transitionTimingFunction: 'cubic-bezier(0.4, 0, 0.2, 1)',
   transitionDuration: '100ms',
-
+  '&:disabled': {
+    opacity: 0.7,
+    cursor: 'unset'
+  },
   variants: {
     color: {
       default: {
         backgroundColor: '$defaultButtonBackground',
         color: '$defaultButtonText',
         borderColor: '$defaultButtonBorder',
-        '&:hover': {
+        '&:hover:not(:disabled)': {
           backgroundColor: '$defaultButtonBackgroundHover',
         },
+
       },
       primary: {
         backgroundColor: '$brand',
         color: '$brandButtonText',
         borderColor: '$brandAccent',
-        '&:hover': {
+        '&:hover:not(:disabled)': {
           backgroundColor: '$brandAccent',
         },
       },

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -109,6 +109,7 @@ export type I18nVariables = {
     email_input_placeholder?: string
     password_input_placeholder?: string
     button_label?: string
+    loading_button_label?: string
     social_provider_text?: string
     link_text?: string
   }
@@ -118,6 +119,7 @@ export type I18nVariables = {
     email_input_placeholder?: string
     password_input_placeholder?: string
     button_label?: string
+    loading_button_label?: string
     social_provider_text?: string
     link_text?: string
   }


### PR DESCRIPTION
## What kind of change does this PR introduce?
Feature proposal for a small UI change in order to provide a visual feedback to the user while an action (login, registration ...) is performed. I would like to present the "loading state" to the end user by updating the submit button style and label.

## What is the current behavior?
Right now nothing happens on the UI once the form is submitted and the end user might think that the app is not working properly.

## What is the new behavior?
Once the form is submitted and the internal state is "loading", the button gets styled with less opacity and its label changes to something else more meaningful.
<img width="384" alt="Screenshot 2023-02-06 alle 17 32 28" src="https://user-images.githubusercontent.com/15871923/217029297-6aa0207e-ca86-40e4-9eb5-4a02bb1c5512.png">

## Additional context
I only implemented this change for the `EmailAuth` component (`sign_in`, `sign_up` views), but if you like the idea I'll do the other forms as well.