### PR TITLE
feat: add confirmation variable on localization for custom message

### DIFF
--- a/.changeset/breezy-trees-appear.md
+++ b/.changeset/breezy-trees-appear.md
@@ -1,0 +1,5 @@
+---
+'@supabase/auth-ui-react': patch
+---
+
+Add confirmation variable to localization for custom message

--- a/packages/react/common/lib/Localization/en.json
+++ b/packages/react/common/lib/Localization/en.json
@@ -7,7 +7,8 @@
     "button_label": "Sign up",
     "loading_button_label": "Signing up ...",
     "social_provider_text": "Sign in with",
-    "link_text": "Don't have an account? Sign up"
+    "link_text": "Don't have an account? Sign up",
+    "confirmation_text": "Check your email for the confirmation link"
   },
   "sign_in": {
     "email_label": "Email address",

--- a/packages/react/src/components/Auth/interfaces/EmailAuth.tsx
+++ b/packages/react/src/components/Auth/interfaces/EmailAuth.tsx
@@ -89,7 +89,9 @@ function EmailAuth({
         if (signUpError) setError(signUpError.message)
         // Check if session is null -> email confirmation setting is turned on
         else if (signUpUser && !signUpSession)
-          setMessage('Check your email for the confirmation link.')
+          setMessage(i18n?.sign_up?.confirmation_text ||
+                     'Check your email for the confirmation link.'
+                    )
         break
     }
 

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -112,6 +112,7 @@ export type I18nVariables = {
     loading_button_label?: string
     social_provider_text?: string
     link_text?: string
+    confirmation_text?: string
   }
   sign_in?: {
     email_label?: string


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature: add confirmation variable on localization for custom message.

## What is the current behavior?

When you press to sign up button, there's a hard-coded message saying "Check your email for the confirmation link."

## What is the new behavior?

Now, you can change the message that appears after pressing the sign up button. This was needed since I'm translating all messages to portuguese as needed by my client.

## Additional context

This was discussed on [issue #96](https://github.com/supabase/auth-ui/issues/96) and on [issue #12368](https://github.com/supabase/supabase/discussions/12368#discussioncomment-4951676) on supabase repo
