### PR TITLE
Feature: Add SocialAuth to Magic Link view

### DIFF
--- a/packages/react/src/components/Auth/Auth.tsx
+++ b/packages/react/src/components/Auth/Auth.tsx
@@ -1,7 +1,7 @@
 import { createStitches, createTheme } from '@stitches/core'
-import { merge } from '../../utils'
 import React, { useEffect, useState } from 'react'
-import { Auth as AuthProps, Localization, I18nVariables } from '../../types'
+import { Auth as AuthProps, I18nVariables, Localization } from '../../types'
+import { merge } from '../../utils'
 import { VIEWS } from './../../constants'
 import {
   EmailAuth,
@@ -55,7 +55,10 @@ function Auth({
    *
    * @returns boolean
    */
-  const SignView = authView === 'sign_in' || authView === 'sign_up'
+  const SignView =
+    authView === 'sign_in' ||
+    authView === 'sign_up' ||
+    authView === 'magic_link'
 
   useEffect(() => {
     /**

--- a/packages/solid/src/components/Auth/Auth.tsx
+++ b/packages/solid/src/components/Auth/Auth.tsx
@@ -81,7 +81,11 @@ function Auth(props: AuthProps): JSX.Element | null {
   const [SignView, setSignView] = createSignal()
 
   onMount(() => {
-    setSignView(authView() === 'sign_in' || authView() === 'sign_up')
+    setSignView(
+      authView() === 'sign_in' ||
+        authView() === 'sign_up' ||
+        authView() === 'magic_link'
+    )
   })
 
   createEffect(() => {
@@ -94,7 +98,11 @@ function Auth(props: AuthProps): JSX.Element | null {
      * to add a new theme use  createTheme({})
      * https://stitches.dev/docs/api#theme
      */
-    setSignView(authView() === 'sign_in' || authView() === 'sign_up')
+    setSignView(
+      authView() === 'sign_in' ||
+        authView() === 'sign_up' ||
+        authView() === 'magic_link'
+    )
     createStitches({
       theme: merge(
         mergedProps().appearance?.theme?.default ?? {},

--- a/packages/svelte/src/lib/Auth/Auth.svelte
+++ b/packages/svelte/src/lib/Auth/Auth.svelte
@@ -60,6 +60,8 @@
 		<ForgottenPassword {i18n} {supabaseClient} {authView} />
 	{/if}
 	{#if $authView === AuthView.MAGIC_LINK}
+		<SocialAuth {i18n} {supabaseClient} {providers} {redirectTo} {iconsOnly} />
+		
 		<MagicLink {i18n} {supabaseClient} {authView} />
 	{/if}
 	{#if $authView === AuthView.UPDATE_PASSWORD}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature: SocialAuth to `magic_link` view

## What is the current behavior?

Currently, you can only see the social auth providers when the view is `sign_in`

## What is the new behavior?

When the view is `magic_link` the auth providers will be visible as well

## Additional context

![image](https://user-images.githubusercontent.com/5108929/219983107-74189449-68f1-4a43-b192-7e677281d590.png)

