### PR TITLE
Add emailRedirectTo to signup in React

### DIFF
--- a/.changeset/friendly-ants-float.md
+++ b/.changeset/friendly-ants-float.md
@@ -1,0 +1,5 @@
+---
+'@supabase/auth-ui-react': patch
+---
+
+Add emailRedirectTo property to the EmailAuth component's signUp method

--- a/packages/react/src/components/Auth/interfaces/EmailAuth.tsx
+++ b/packages/react/src/components/Auth/interfaces/EmailAuth.tsx
@@ -86,8 +86,8 @@ function EmailAuth({
           email,
           password,
           options: {
-						emailRedirectTo: redirectTo
-					}
+	    emailRedirectTo: redirectTo
+	  }
         })
         if (signUpError) setError(signUpError.message)
         // Check if session is null -> email confirmation setting is turned on

--- a/packages/react/src/components/Auth/interfaces/EmailAuth.tsx
+++ b/packages/react/src/components/Auth/interfaces/EmailAuth.tsx
@@ -85,6 +85,9 @@ function EmailAuth({
         } = await supabaseClient.auth.signUp({
           email,
           password,
+          options: {
+						emailRedirectTo: redirectTo
+					}
         })
         if (signUpError) setError(signUpError.message)
         // Check if session is null -> email confirmation setting is turned on


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes https://github.com/supabase/auth-ui/issues/117
Fixes https://github.com/supabase/auth-ui/issues/72
Fixes https://github.com/supabase/auth-ui/issues/76

## What is the current behavior?

Doesn't redirect

## What is the new behavior?

Redirects to the url provided

## Additional context

Could I get some help testing this change?