### PR TITLE
Pass redirectTo during sign-up in EmailAuth.tsx in Solid package

### DIFF
--- a/packages/solid/src/components/Auth/interfaces/EmailAuth.tsx
+++ b/packages/solid/src/components/Auth/interfaces/EmailAuth.tsx
@@ -78,6 +78,9 @@ function EmailAuth(props: EmailAuthProps) {
         } = await props.supabaseClient.auth.signUp({
           email: email(),
           password: password(),
+          options: {
+            emailRedirectTo: props.redirectTo,
+          },
         })
         if (signUpError) setError(signUpError.message)
         // Check if session is null -> email confirmation setting is turned on


### PR DESCRIPTION
## What kind of change does this PR introduce?

This fix is similar to [#128](https://github.com/supabase/auth-ui/pull/128), but for the Solid package.

Passes the `redirectTo` prop when calling `auth.signUp` in `/packages/solid/src/components/Auth/interfaces/EmailAuth.tsx`.

## What is the current behavior?

When defining the `redirectTo` prop for sign up, it is currently ignored.

## What is the new behavior?

The `redirectTo` prop is now passed to the `auth.signUp` call (via `options.emailRedirectTo`) so that it actually gets used.

## Additional context

None.
