### PR TITLE
bug icon size default change to 21px

### DIFF
--- a/.changeset/chatty-crabs-tap.md
+++ b/.changeset/chatty-crabs-tap.md
@@ -1,0 +1,7 @@
+---
+'@supabase/auth-ui-react': patch
+'@supabase/auth-ui-solid': patch
+'@supabase/auth-ui-svelte': patch
+---
+
+Change icon size default change to 21px

--- a/packages/react/src/components/Auth/Icons.tsx
+++ b/packages/react/src/components/Auth/Icons.tsx
@@ -11,8 +11,8 @@ export const google = () => (
     className={iconDefaultStyles()}
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 48 48"
-    width="512px"
-    height="512px"
+    width="21px"
+    height="21px"
   >
     <path
       fill="#FFC107"
@@ -38,8 +38,8 @@ export const facebook = () => (
     className={iconDefaultStyles()}
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 48 48"
-    width="512px"
-    height="512px"
+    width="21px"
+    height="21px"
   >
     <path fill="#039be5" d="M24 5A19 19 0 1 0 24 43A19 19 0 1 0 24 5Z" />
     <path
@@ -54,8 +54,8 @@ export const twitter = () => (
     className={iconDefaultStyles()}
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 48 48"
-    width="512px"
-    height="512px"
+    width="21px"
+    height="21px"
   >
     <path
       fill="#03A9F4"
@@ -70,8 +70,8 @@ export const apple = () => (
     fill="gray"
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 24 24"
-    width="512px"
-    height="512px"
+    width="21px"
+    height="21px"
   >
     {' '}
     <path d="M 15.904297 1.078125 C 15.843359 1.06875 15.774219 1.0746094 15.699219 1.0996094 C 14.699219 1.2996094 13.600391 1.8996094 12.900391 2.5996094 C 12.300391 3.1996094 11.800781 4.1996094 11.800781 5.0996094 C 11.800781 5.2996094 11.999219 5.5 12.199219 5.5 C 13.299219 5.4 14.399609 4.7996094 15.099609 4.0996094 C 15.699609 3.2996094 16.199219 2.4 16.199219 1.5 C 16.199219 1.275 16.087109 1.10625 15.904297 1.078125 z M 16.199219 5.4003906 C 14.399219 5.4003906 13.600391 6.5 12.400391 6.5 C 11.100391 6.5 9.9003906 5.5 8.4003906 5.5 C 6.3003906 5.5 3.0996094 7.4996094 3.0996094 12.099609 C 2.9996094 16.299609 6.8 21 9 21 C 10.3 21 10.600391 20.199219 12.400391 20.199219 C 14.200391 20.199219 14.600391 21 15.900391 21 C 17.400391 21 18.500391 19.399609 19.400391 18.099609 C 19.800391 17.399609 20.100391 17.000391 20.400391 16.400391 C 20.600391 16.000391 20.4 15.600391 20 15.400391 C 17.4 14.100391 16.900781 9.9003906 19.800781 8.4003906 C 20.300781 8.1003906 20.4 7.4992188 20 7.1992188 C 18.9 6.1992187 17.299219 5.4003906 16.199219 5.4003906 z" />
@@ -84,8 +84,8 @@ export const github = () => (
     fill="gray"
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 30 30"
-    width="512px"
-    height="512px"
+    width="21px"
+    height="21px"
   >
     {' '}
     <path d="M15,3C8.373,3,3,8.373,3,15c0,5.623,3.872,10.328,9.092,11.63C12.036,26.468,12,26.28,12,26.047v-2.051 c-0.487,0-1.303,0-1.508,0c-0.821,0-1.551-0.353-1.905-1.009c-0.393-0.729-0.461-1.844-1.435-2.526 c-0.289-0.227-0.069-0.486,0.264-0.451c0.615,0.174,1.125,0.596,1.605,1.222c0.478,0.627,0.703,0.769,1.596,0.769 c0.433,0,1.081-0.025,1.691-0.121c0.328-0.833,0.895-1.6,1.588-1.962c-3.996-0.411-5.903-2.399-5.903-5.098 c0-1.162,0.495-2.286,1.336-3.233C9.053,10.647,8.706,8.73,9.435,8c1.798,0,2.885,1.166,3.146,1.481C13.477,9.174,14.461,9,15.495,9 c1.036,0,2.024,0.174,2.922,0.483C18.675,9.17,19.763,8,21.565,8c0.732,0.731,0.381,2.656,0.102,3.594 c0.836,0.945,1.328,2.066,1.328,3.226c0,2.697-1.904,4.684-5.894,5.097C18.199,20.49,19,22.1,19,23.313v2.734 c0,0.104-0.023,0.179-0.035,0.268C23.641,24.676,27,20.236,27,15C27,8.373,21.627,3,15,3z" />
@@ -97,8 +97,8 @@ export const gitlab = () => (
     className={iconDefaultStyles()}
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 48 48"
-    width="512px"
-    height="512px"
+    width="21px"
+    height="21px"
   >
     <path fill="#e53935" d="M24 43L16 20 32 20z" />
     <path fill="#ff7043" d="M24 43L42 20 32 20z" />
@@ -151,8 +151,8 @@ export const discord = () => (
     className={iconDefaultStyles()}
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 48 48"
-    width="512px"
-    height="512px"
+    width="21px"
+    height="21px"
   >
     <path
       fill="#536dfe"
@@ -166,8 +166,8 @@ export const azure = () => (
     className={iconDefaultStyles()}
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 48 48"
-    width="512px"
-    height="512px"
+    width="21px"
+    height="21px"
   >
     <linearGradient
       id="k8yl7~hDat~FaoWq8WjN6a"
@@ -248,8 +248,8 @@ export const linkedin = () => (
     className={iconDefaultStyles()}
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 48 48"
-    width="512px"
-    height="512px"
+    width="21px"
+    height="21px"
   >
     <path
       fill="#0288D1"
@@ -267,8 +267,8 @@ export const notion = () => (
     className={iconDefaultStyles()}
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 48 48"
-    width="512px"
-    height="512px"
+    width="21px"
+    height="21px"
     fillRule="evenodd"
     clipRule="evenodd"
   >
@@ -298,8 +298,8 @@ export const slack = () => (
     className={iconDefaultStyles()}
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 48 48"
-    width="512px"
-    height="512px"
+    width="21px"
+    height="21px"
   >
     <path
       fill="#33d375"

--- a/packages/solid/src/components/Auth/Icons.tsx
+++ b/packages/solid/src/components/Auth/Icons.tsx
@@ -10,8 +10,8 @@ export const google = () => (
     class={iconDefaultStyles()}
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 48 48"
-    width="512px"
-    height="512px"
+    width="21px"
+    height="21px"
   >
     <path
       fill="#FFC107"
@@ -37,8 +37,8 @@ export const facebook = () => (
     class={iconDefaultStyles()}
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 48 48"
-    width="512px"
-    height="512px"
+    width="21px"
+    height="21px"
   >
     <path fill="#039be5" d="M24 5A19 19 0 1 0 24 43A19 19 0 1 0 24 5Z" />
     <path
@@ -53,8 +53,8 @@ export const twitter = () => (
     class={iconDefaultStyles()}
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 48 48"
-    width="512px"
-    height="512px"
+    width="21px"
+    height="21px"
   >
     <path
       fill="#03A9F4"
@@ -69,8 +69,8 @@ export const apple = () => (
     fill="gray"
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 24 24"
-    width="512px"
-    height="512px"
+    width="21px"
+    height="21px"
   >
     {' '}
     <path d="M 15.904297 1.078125 C 15.843359 1.06875 15.774219 1.0746094 15.699219 1.0996094 C 14.699219 1.2996094 13.600391 1.8996094 12.900391 2.5996094 C 12.300391 3.1996094 11.800781 4.1996094 11.800781 5.0996094 C 11.800781 5.2996094 11.999219 5.5 12.199219 5.5 C 13.299219 5.4 14.399609 4.7996094 15.099609 4.0996094 C 15.699609 3.2996094 16.199219 2.4 16.199219 1.5 C 16.199219 1.275 16.087109 1.10625 15.904297 1.078125 z M 16.199219 5.4003906 C 14.399219 5.4003906 13.600391 6.5 12.400391 6.5 C 11.100391 6.5 9.9003906 5.5 8.4003906 5.5 C 6.3003906 5.5 3.0996094 7.4996094 3.0996094 12.099609 C 2.9996094 16.299609 6.8 21 9 21 C 10.3 21 10.600391 20.199219 12.400391 20.199219 C 14.200391 20.199219 14.600391 21 15.900391 21 C 17.400391 21 18.500391 19.399609 19.400391 18.099609 C 19.800391 17.399609 20.100391 17.000391 20.400391 16.400391 C 20.600391 16.000391 20.4 15.600391 20 15.400391 C 17.4 14.100391 16.900781 9.9003906 19.800781 8.4003906 C 20.300781 8.1003906 20.4 7.4992188 20 7.1992188 C 18.9 6.1992187 17.299219 5.4003906 16.199219 5.4003906 z" />
@@ -83,8 +83,8 @@ export const github = () => (
     fill="gray"
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 30 30"
-    width="512px"
-    height="512px"
+    width="21px"
+    height="21px"
   >
     {' '}
     <path d="M15,3C8.373,3,3,8.373,3,15c0,5.623,3.872,10.328,9.092,11.63C12.036,26.468,12,26.28,12,26.047v-2.051 c-0.487,0-1.303,0-1.508,0c-0.821,0-1.551-0.353-1.905-1.009c-0.393-0.729-0.461-1.844-1.435-2.526 c-0.289-0.227-0.069-0.486,0.264-0.451c0.615,0.174,1.125,0.596,1.605,1.222c0.478,0.627,0.703,0.769,1.596,0.769 c0.433,0,1.081-0.025,1.691-0.121c0.328-0.833,0.895-1.6,1.588-1.962c-3.996-0.411-5.903-2.399-5.903-5.098 c0-1.162,0.495-2.286,1.336-3.233C9.053,10.647,8.706,8.73,9.435,8c1.798,0,2.885,1.166,3.146,1.481C13.477,9.174,14.461,9,15.495,9 c1.036,0,2.024,0.174,2.922,0.483C18.675,9.17,19.763,8,21.565,8c0.732,0.731,0.381,2.656,0.102,3.594 c0.836,0.945,1.328,2.066,1.328,3.226c0,2.697-1.904,4.684-5.894,5.097C18.199,20.49,19,22.1,19,23.313v2.734 c0,0.104-0.023,0.179-0.035,0.268C23.641,24.676,27,20.236,27,15C27,8.373,21.627,3,15,3z" />
@@ -96,8 +96,8 @@ export const gitlab = () => (
     class={iconDefaultStyles()}
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 48 48"
-    width="512px"
-    height="512px"
+    width="21px"
+    height="21px"
   >
     <path fill="#e53935" d="M24 43L16 20 32 20z" />
     <path fill="#ff7043" d="M24 43L42 20 32 20z" />
@@ -112,8 +112,8 @@ export const bitbucket = () => (
   <svg
     class={iconDefaultStyles()}
     xmlns="http://www.w3.org/2000/svg"
-    width="512"
-    height="512"
+    width="21px"
+    height="21px"
     viewBox="0 0 62.42 62.42"
   >
     <defs>
@@ -150,8 +150,8 @@ export const discord = () => (
     class={iconDefaultStyles()}
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 48 48"
-    width="512px"
-    height="512px"
+    width="21px"
+    height="21px"
   >
     <path
       fill="#536dfe"
@@ -165,8 +165,8 @@ export const azure = () => (
     class={iconDefaultStyles()}
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 48 48"
-    width="512px"
-    height="512px"
+    width="21px"
+    height="21px"
   >
     <linearGradient
       id="k8yl7~hDat~FaoWq8WjN6a"
@@ -229,8 +229,8 @@ export const azure = () => (
 export const keycloak = () => (
   <svg
     class={iconDefaultStyles()}
-    width="512"
-    height="512"
+    width="21px"
+    height="21px"
     viewBox="0 0 512 512"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
@@ -247,8 +247,8 @@ export const linkedin = () => (
     class={iconDefaultStyles()}
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 48 48"
-    width="512px"
-    height="512px"
+    width="21px"
+    height="21px"
   >
     <path
       fill="#0288D1"
@@ -266,8 +266,8 @@ export const notion = () => (
     class={iconDefaultStyles()}
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 48 48"
-    width="512px"
-    height="512px"
+    width="21px"
+    height="21px"
     fill-rule="evenodd"
     clip-rule="evenodd"
   >
@@ -297,8 +297,8 @@ export const slack = () => (
     class={iconDefaultStyles()}
     xmlns="http://www.w3.org/2000/svg"
     viewBox="0 0 48 48"
-    width="512px"
-    height="512px"
+    width="21px"
+    height="21px"
   >
     <path
       fill="#33d375"
@@ -338,8 +338,8 @@ export const slack = () => (
 export const spotify = () => (
   <svg
     class={iconDefaultStyles()}
-    width="512"
-    height="512"
+    width="21px"
+    height="21px"
     viewBox="0 0 512 512"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
@@ -354,8 +354,8 @@ export const spotify = () => (
 export const twitch = () => (
   <svg
     class={iconDefaultStyles()}
-    width="512"
-    height="512"
+    width="21px"
+    height="21px"
     viewBox="0 0 512 512"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"
@@ -373,8 +373,8 @@ export const twitch = () => (
 export const workos = () => (
   <svg
     class={iconDefaultStyles()}
-    width="512"
-    height="512"
+    width="21px"
+    height="21px"
     viewBox="0 0 512 512"
     fill="none"
     xmlns="http://www.w3.org/2000/svg"

--- a/packages/svelte/src/lib/Auth/Icons.svelte
+++ b/packages/svelte/src/lib/Auth/Icons.svelte
@@ -5,7 +5,7 @@
 </script>
 
 {#if provider === 'google'}
-	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="512px" height="512px">
+	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="21px" height="21px">
 		<path
 			fill="#FFC107"
 			d="M43.611,20.083H42V20H24v8h11.303c-1.649,4.657-6.08,8-11.303,8c-6.627,0-12-5.373-12-12c0-6.627,5.373-12,12-12c3.059,0,5.842,1.154,7.961,3.039l5.657-5.657C34.046,6.053,29.268,4,24,4C12.955,4,4,12.955,4,24c0,11.045,8.955,20,20,20c11.045,0,20-8.955,20-20C44,22.659,43.862,21.35,43.611,20.083z"
@@ -24,7 +24,7 @@
 		/>
 	</svg>
 {:else if provider === 'facebook'}
-	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="512px" height="512px">
+	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="21px"" height="21px">
 		<path fill="#039be5" d="M24 5A19 19 0 1 0 24 43A19 19 0 1 0 24 5Z" />
 		<path
 			fill="#fff"
@@ -32,7 +32,7 @@
 		/>
 	</svg>
 {:else if provider === 'twitter'}
-	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="512px" height="512px">
+	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="21px" height="21px">
 		<path
 			fill="#03A9F4"
 			d="M42,12.429c-1.323,0.586-2.746,0.977-4.247,1.162c1.526-0.906,2.7-2.351,3.251-4.058c-1.428,0.837-3.01,1.452-4.693,1.776C34.967,9.884,33.05,9,30.926,9c-4.08,0-7.387,3.278-7.387,7.32c0,0.572,0.067,1.129,0.193,1.67c-6.138-0.308-11.582-3.226-15.224-7.654c-0.64,1.082-1,2.349-1,3.686c0,2.541,1.301,4.778,3.285,6.096c-1.211-0.037-2.351-0.374-3.349-0.914c0,0.022,0,0.055,0,0.086c0,3.551,2.547,6.508,5.923,7.181c-0.617,0.169-1.269,0.263-1.941,0.263c-0.477,0-0.942-0.054-1.392-0.135c0.94,2.902,3.667,5.023,6.898,5.086c-2.528,1.96-5.712,3.134-9.174,3.134c-0.598,0-1.183-0.034-1.761-0.104C9.268,36.786,13.152,38,17.321,38c13.585,0,21.017-11.156,21.017-20.834c0-0.317-0.01-0.633-0.025-0.945C39.763,15.197,41.013,13.905,42,12.429"
@@ -43,8 +43,8 @@
 		fill="gray"
 		xmlns="http://www.w3.org/2000/svg"
 		viewBox="0 0 24 24"
-		width="512px"
-		height="512px"
+		width="21px"
+		height="21px"
 	>
 		{' '}
 		<path
@@ -56,8 +56,8 @@
 		fill="gray"
 		xmlns="http://www.w3.org/2000/svg"
 		viewBox="0 0 30 30"
-		width="512px"
-		height="512px"
+		width="21px"
+		height="21px"
 	>
 		{' '}
 		<path
@@ -65,7 +65,7 @@
 		/>
 	</svg>
 {:else if provider === 'gitlab'}
-	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="512px" height="512px">
+	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="21px" height="21px">
 		<path fill="#e53935" d="M24 43L16 20 32 20z" />
 		<path fill="#ff7043" d="M24 43L42 20 32 20z" />
 		<path fill="#e53935" d="M37 5L42 20 32 20z" />
@@ -75,7 +75,7 @@
 		<path fill="#ffa726" d="M24 43L6 20 3 28z" />
 	</svg>
 {:else if provider === 'bitbucket'}
-	<svg xmlns="http://www.w3.org/2000/svg" width="512" height="512" viewBox="0 0 62.42 62.42">
+	<svg xmlns="http://www.w3.org/2000/svg" width="21px" height="21px" viewBox="0 0 62.42 62.42">
 		<defs>
 			<linearGradient
 				id="New_Gradient_Swatch_1"
@@ -104,14 +104,14 @@
 		</g>
 	</svg>
 {:else if provider === 'discord'}
-	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="512px" height="512px">
+	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="21px" height="21px">
 		<path
 			fill="#536dfe"
 			d="M39.248,10.177c-2.804-1.287-5.812-2.235-8.956-2.778c-0.057-0.01-0.114,0.016-0.144,0.068	c-0.387,0.688-0.815,1.585-1.115,2.291c-3.382-0.506-6.747-0.506-10.059,0c-0.3-0.721-0.744-1.603-1.133-2.291	c-0.03-0.051-0.087-0.077-0.144-0.068c-3.143,0.541-6.15,1.489-8.956,2.778c-0.024,0.01-0.045,0.028-0.059,0.051	c-5.704,8.522-7.267,16.835-6.5,25.044c0.003,0.04,0.026,0.079,0.057,0.103c3.763,2.764,7.409,4.442,10.987,5.554	c0.057,0.017,0.118-0.003,0.154-0.051c0.846-1.156,1.601-2.374,2.248-3.656c0.038-0.075,0.002-0.164-0.076-0.194	c-1.197-0.454-2.336-1.007-3.432-1.636c-0.087-0.051-0.094-0.175-0.014-0.234c0.231-0.173,0.461-0.353,0.682-0.534	c0.04-0.033,0.095-0.04,0.142-0.019c7.201,3.288,14.997,3.288,22.113,0c0.047-0.023,0.102-0.016,0.144,0.017	c0.22,0.182,0.451,0.363,0.683,0.536c0.08,0.059,0.075,0.183-0.012,0.234c-1.096,0.641-2.236,1.182-3.434,1.634	c-0.078,0.03-0.113,0.12-0.075,0.196c0.661,1.28,1.415,2.498,2.246,3.654c0.035,0.049,0.097,0.07,0.154,0.052	c3.595-1.112,7.241-2.79,11.004-5.554c0.033-0.024,0.054-0.061,0.057-0.101c0.917-9.491-1.537-17.735-6.505-25.044	C39.293,10.205,39.272,10.187,39.248,10.177z M16.703,30.273c-2.168,0-3.954-1.99-3.954-4.435s1.752-4.435,3.954-4.435	c2.22,0,3.989,2.008,3.954,4.435C20.658,28.282,18.906,30.273,16.703,30.273z M31.324,30.273c-2.168,0-3.954-1.99-3.954-4.435	s1.752-4.435,3.954-4.435c2.22,0,3.989,2.008,3.954,4.435C35.278,28.282,33.544,30.273,31.324,30.273z"
 		/>
 	</svg>
 {:else if provider === 'azure'}
-	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="512px" height="512px">
+	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="21px" height="21px">
 		<linearGradient
 			id="k8yl7~hDat~FaoWq8WjN6a"
 			x1="-1254.397"
@@ -170,8 +170,8 @@
 	</svg>
 {:else if provider === 'keycloak'}
 	<svg
-		width="512"
-		height="512"
+		width="21px"
+		height="21px"
 		viewBox="0 0 512 512"
 		fill="none"
 		xmlns="http://www.w3.org/2000/svg"
@@ -182,7 +182,7 @@
 		/>
 	</svg>
 {:else if provider === 'linkedin'}
-	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="512px" height="512px">
+	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="21px" height="21px">
 		<path
 			fill="#0288D1"
 			d="M42,37c0,2.762-2.238,5-5,5H11c-2.761,0-5-2.238-5-5V11c0-2.762,2.239-5,5-5h26c2.762,0,5,2.238,5,5V37z"
@@ -196,8 +196,8 @@
 	<svg
 		xmlns="http://www.w3.org/2000/svg"
 		viewBox="0 0 48 48"
-		width="512px"
-		height="512px"
+		width="21px"
+		height="21px"
 		fill-rule="evenodd"
 		clip-rule="evenodd"
 	>
@@ -221,7 +221,7 @@
 		/>
 	</svg>
 {:else if provider === 'slack'}
-	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="512px" height="512px">
+	<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" width="21px" height="21px">
 		<path
 			fill="#33d375"
 			d="M33,8c0-2.209-1.791-4-4-4s-4,1.791-4,4c0,1.254,0,9.741,0,11c0,2.209,1.791,4,4,4s4-1.791,4-4	C33,17.741,33,9.254,33,8z"
@@ -257,8 +257,8 @@
 	</svg>
 {:else if provider === 'spotify'}
 	<svg
-		width="512"
-		height="512"
+		width="21px"
+		height="21px"
 		viewBox="0 0 512 512"
 		fill="none"
 		xmlns="http://www.w3.org/2000/svg"
@@ -270,8 +270,8 @@
 	</svg>
 {:else if provider === 'twitch'}
 	<svg
-		width="512"
-		height="512"
+		width="21px"
+		height="21px"
 		viewBox="0 0 512 512"
 		fill="none"
 		xmlns="http://www.w3.org/2000/svg"
@@ -286,8 +286,8 @@
 	</svg>
 {:else if provider === 'workos'}
 	<svg
-		width="512"
-		height="512"
+		width="21px"
+		height="21px"
 		viewBox="0 0 512 512"
 		fill="none"
 		xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
The default styled size of the icons is 21px to make them small enough
to display properly in the button. However the SVG was setup with the
default size of 512px which causes a momentary fash of a large icon as
the page loads. This change sets the default size to 21px.

If a larger size is required in the future it can be overridden through
the styles prop just like the current implementation.