### PR TITLE
fixed button not being disabled on svelte

### DIFF
--- a/packages/svelte/src/lib/Auth/interfaces/EmailAuth.svelte
+++ b/packages/svelte/src/lib/Auth/interfaces/EmailAuth.svelte
@@ -89,7 +89,7 @@
 				/>
 			</div>
 		</Container>
-		<Button type="submit" color="primary" {appearance}>{i18n?.[lngKey]?.button_label}</Button>
+		<Button type="submit" color="primary" {loading} {appearance}>{i18n?.[lngKey]?.button_label}</Button>
 
 		{#if showLinks}
 			<Container direction="vertical" gap="small" {appearance}>

--- a/packages/svelte/src/lib/UI/Button.svelte
+++ b/packages/svelte/src/lib/UI/Button.svelte
@@ -11,11 +11,12 @@
 
 	export let color: 'default' | 'primary' = 'default';
 	export let appearance: Appearance = {};
+  export let loading = false;
 
 	$: classNames = generateClassNames('button', color, appearance);
 </script>
 
-<button on:click {...$$restProps} style={appearance?.style?.button} class={classNames.join(' ')}>
+<button on:click {...$$restProps} disabled={loading} style={appearance?.style?.button} class={classNames.join(' ')}>
 	<slot />
 </button>
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fixes a bug where the button isn't being disabled because the `loading` prop is being passed as is instead of being passed as a value for `disabled`. This also fixes the `EmailAuth` component not passing the `loading` value to it's button.

## What is the current behavior?

The button isn't being disabled when the form is submitted, making it look like the form is unresponsive.

## What is the new behavior?

The form should now be working as expected.

