### PR TITLE
feat: Enhance actions based on current view

### DIFF
--- a/packages/react/src/components/Auth/Auth.tsx
+++ b/packages/react/src/components/Auth/Auth.tsx
@@ -30,6 +30,7 @@ function Auth({
   otpType = 'email',
   additionalData,
   children,
+  onViewChange,
 }: AuthProps): JSX.Element | null {
   /**
    * Localization support
@@ -119,6 +120,14 @@ function Auth({
 
     return () => authListener.subscription.unsubscribe()
   }, [view])
+
+  useEffect(() => {
+    if (typeof onViewChange !== 'function') {
+      return;
+    }
+
+    onViewChange(authView);
+  }, [authView]);
 
   const emailProp: Omit<EmailAuthProps, 'authView' | 'id'> = {
     supabaseClient,

--- a/packages/react/src/types.ts
+++ b/packages/react/src/types.ts
@@ -1,4 +1,4 @@
-import { BaseAppearance, BaseAuth } from '@supabase/auth-ui-shared'
+import { BaseAppearance, BaseAuth, ViewType } from '@supabase/auth-ui-shared'
 import { CSSProperties, ReactNode } from 'react'
 
 export interface Appearance extends BaseAppearance {
@@ -17,4 +17,5 @@ export interface Appearance extends BaseAppearance {
 export interface Auth extends BaseAuth {
   children?: ReactNode
   appearance?: Appearance
+  onViewChange?: (view: ViewType) => void
 }


### PR DESCRIPTION
This commit enhances the capability to perform additional actions based on the current view. It allows for customized actions, such as displaying messages, logging events, and hiding/displaying components, depending on the view. This improvement provides greater flexibility and customization options for different page states.

## What kind of change does this PR introduce?

This PR introduces a new feature.

## What is the current behavior?

Currently, when on the "Sign in" page and clicking on "Forgot your password?", there is no indication or way to know that the user has been navigated to another display. ([https://github.com/orgs/supabase/discussions/14646](https://github.com/orgs/supabase/discussions/14646))

## What is the new behavior?

This PR enhances the capability to perform additional actions based on the current view. It introduces the ability to do additional actions, such as displaying additional messages or components on the page depending on the view, adding logging functionality, and selectively hiding or displaying components. This change allows for better user feedback and customization based on the current view.

## Additional context

This enhancement provides more flexibility and customization options for different page states, improving the overall user experience.