### PR TITLE
[Fix] pass the missing redirectTo field to ForgottenPassword component

### DIFF
--- a/.changeset/perfect-islands-listen.md
+++ b/.changeset/perfect-islands-listen.md
@@ -1,0 +1,5 @@
+---
+'@supabase/auth-ui-svelte': patch
+---
+
+fix: pass the missing redirectTo field to ForgottenPassword component.

--- a/packages/svelte/src/lib/Auth/Auth.svelte
+++ b/packages/svelte/src/lib/Auth/Auth.svelte
@@ -113,7 +113,7 @@
 		{/if}
 	{/if}
 	{#if view === VIEWS.FORGOTTEN_PASSWORD}
-		<ForgottenPassword {i18n} {supabaseClient} bind:authView={view} {showLinks} {appearance} />
+		<ForgottenPassword {i18n} {supabaseClient} bind:authView={view} {showLinks} {appearance} {redirectTo} />
 	{/if}
 	{#if view === VIEWS.MAGIC_LINK}
 		<MagicLink {i18n} {supabaseClient} bind:authView={view} {appearance} {redirectTo} {showLinks} />


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix: pass the missing `redirectTo` field to `ForgottenPassword` component.

## What is the current behavior?

The `redirectTo` field doesn't take effect when the Auth view is FORGOTTEN_PASSWORD. This makes the reset password email link doesn't have `redirectTo` param set as expected.

## What is the new behavior?

The reset password email link should have the expected `redirectTo` field set. 

## Additional context

N/A