### PR TITLE
fix(auth-ui-svelte): make additionalData prop optional

### DIFF
--- a/.changeset/tame-mails-act.md
+++ b/.changeset/tame-mails-act.md
@@ -1,0 +1,5 @@
+---
+'@supabase/auth-ui-svelte': patch
+---
+
+Make additionalData optional by default

--- a/packages/svelte/src/lib/Auth/Auth.svelte
+++ b/packages/svelte/src/lib/Auth/Auth.svelte
@@ -34,7 +34,7 @@
 	export let theme: 'default' | string = 'default';
 	export let localization: { variables?: I18nVariables } = {};
 	export let otpType: OtpType = 'email';
-	export let additionalData: { [key: string]: any } | undefined;
+	export let additionalData: { [key: string]: any } | undefined = undefined;
 
 	onMount(() => {
 		const { data: authListener } = supabaseClient.auth.onAuthStateChange((event) => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

**Bug fix**

Previous behavior: TypeScript shows an error if the `additionalData` prop is not explicitly set on the Svelte [Auth component](https://github.com/supabase/auth-ui/blob/main/packages/svelte/src/lib/Auth/Auth.svelte).

Since `additionalData` is defined as optional in [shared/src/types.ts](https://github.com/supabase/auth-ui/blob/main/packages/shared/src/types.ts#L96) it makes sense to also make it optional for the Svelte Auth component. 

![error](https://github.com/supabase/auth-ui/assets/68379148/698976ed-f2c2-4c0c-8698-6072cedf3101)


## What is the new behavior?

The `additionalData` prop for the Svelte `Auth` component is now optional and doesn't need to be explicitly set. This prevents a scenario like this in TypeScript:

```ts
<script lang="ts">
  import { Auth } from '@supabase/auth-ui-svelte'
</script>

<Auth additionalData={undefined} />
```