### PR TITLE
feat: password letter spacing

### DIFF
--- a/.changeset/dry-candles-roll.md
+++ b/.changeset/dry-candles-roll.md
@@ -1,0 +1,7 @@
+---
+'@supabase/auth-ui-svelte': patch
+'@supabase/auth-ui-react': patch
+'@supabase/auth-ui-solid': patch
+---
+
+Fix password letter spacing

--- a/packages/react/src/components/UI/Input.tsx
+++ b/packages/react/src/components/UI/Input.tsx
@@ -36,7 +36,7 @@ const inputDefaultStyles = css({
         letterSpacing: '0px',
       },
       password: {
-        letterSpacing: '6px',
+        letterSpacing: '0px',
       },
     },
   },

--- a/packages/solid/src/components/UI/Input.tsx
+++ b/packages/solid/src/components/UI/Input.tsx
@@ -37,7 +37,7 @@ const inputDefaultStyles = css({
         letterSpacing: '0px',
       },
       password: {
-        letterSpacing: '6px',
+        letterSpacing: '0px',
       },
     },
   },

--- a/packages/svelte/src/lib/UI/Input.svelte
+++ b/packages/svelte/src/lib/UI/Input.svelte
@@ -37,7 +37,7 @@
 					letterSpacing: '0px'
 				},
 				password: {
-					letterSpacing: '6px'
+					letterSpacing: '0px'
 				}
 			}
 		}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature - Password letter spacing

## What is the current behavior?

Letter spacing seem odd and too spaced out

## What is the new behavior?

<img width="316" alt="Screenshot 2023-09-10 at 17 14 13" src="https://github.com/supabase/auth-ui/assets/22655069/fa81a6b4-7bc4-4ea5-a118-6eef0d67110c">

letter-spacing now set to 0px


## Additional context

Closes #198 
