### PR TITLE
fix: check for blank email address on magic links

### DIFF
--- a/.changeset/pretty-pumpkins-admire.md
+++ b/.changeset/pretty-pumpkins-admire.md
@@ -1,0 +1,6 @@
+---
+'@supabase/auth-ui-shared': patch
+'@supabase/auth-ui-react': patch
+---
+
+Fix check for blank email address on magic links

--- a/packages/react/src/components/Auth/interfaces/MagicLink.tsx
+++ b/packages/react/src/components/Auth/interfaces/MagicLink.tsx
@@ -36,6 +36,12 @@ function MagicLink({
     setError('')
     setMessage('')
     setLoading(true)
+
+    if (email.length === 0) {
+      setError(i18n?.magic_link?.empty_email_address as string)
+      setLoading(false)
+      return
+    }
     const { error } = await supabaseClient.auth.signInWithOtp({
       email,
       options: { emailRedirectTo: redirectTo },
@@ -60,9 +66,10 @@ function MagicLink({
             type="email"
             autoFocus
             placeholder={labels?.email_input_placeholder}
-            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+              if (setError) setError('')
               setEmail(e.target.value)
-            }
+            }}
             appearance={appearance}
           />
         </div>

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -137,6 +137,7 @@ export type I18nVariables = {
     loading_button_label?: string
     link_text?: string
     confirmation_text?: string
+    empty_email_address?: string
   }
   forgotten_password?: {
     email_label?: string


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug Fix

## What is the current behavior?

If you have a blank email address you can still send a request for a magic link and a system error appears.

## What is the new behavior?

Now instead of the system error you get an empty email error and also no request is sent:


https://github.com/supabase/auth-ui/assets/22655069/416e7aee-9226-4ea6-a0b8-c60f201c34dc

## Additional context

Closes #179 
