### PR TITLE
Add resetPasswordRedirectTo prop to Auth component

### DIFF
--- a/packages/react/src/components/Auth/Auth.tsx
+++ b/packages/react/src/components/Auth/Auth.tsx
@@ -21,6 +21,7 @@ function Auth({
   queryParams,
   view = 'sign_in',
   redirectTo,
+  resetPasswordRedirectTo,
   onlyThirdPartyProviders = false,
   magicLink = false,
   showLinks = true,
@@ -173,7 +174,7 @@ function Auth({
             appearance={appearance}
             supabaseClient={supabaseClient}
             setAuthView={setAuthView}
-            redirectTo={redirectTo}
+            redirectTo={resetPasswordRedirectTo ?? redirectTo}
             showLinks={showLinks}
             i18n={i18n}
           />

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -89,6 +89,7 @@ export interface BaseAuth {
   queryParams?: { [key: string]: string }
   view?: ViewType
   redirectTo?: RedirectTo
+  resetPasswordRedirectTo?: RedirectTo
   onlyThirdPartyProviders?: boolean
   magicLink?: boolean
   showLinks?: boolean

--- a/packages/solid/src/components/Auth/Auth.tsx
+++ b/packages/solid/src/components/Auth/Auth.tsx
@@ -259,7 +259,9 @@ function Auth(props: AuthProps): JSX.Element | null {
           appearance={mergedProps().appearance}
           supabaseClient={mergedProps().supabaseClient}
           setAuthView={setAuthView}
-          redirectTo={mergedProps().redirectTo}
+          redirectTo={
+            mergedProps().resetPasswordRedirectTo ?? mergedProps().redirectTo
+          }
           showLinks={mergedProps().showLinks}
           i18n={i18n()}
         />

--- a/packages/svelte/src/lib/Auth/Auth.svelte
+++ b/packages/svelte/src/lib/Auth/Auth.svelte
@@ -27,6 +27,7 @@
 	export let queryParams: { [key: string]: string } | undefined = undefined;
 	export let view: ViewType = 'sign_in';
 	export let redirectTo: string | undefined = undefined;
+	export let resetPasswordRedirectTo: string | undefined = undefined;
 	export let onlyThirdPartyProviders = false;
 	export let magicLink = false;
 	export let showLinks = true;
@@ -113,7 +114,14 @@
 		{/if}
 	{/if}
 	{#if view === VIEWS.FORGOTTEN_PASSWORD}
-		<ForgottenPassword {i18n} {supabaseClient} bind:authView={view} {showLinks} {appearance} {redirectTo} />
+		<ForgottenPassword
+			{i18n}
+			{supabaseClient}
+			bind:authView={view}
+			{showLinks}
+			{appearance}
+			redirectTo={resetPasswordRedirectTo ?? redirectTo}
+		/>
 	{/if}
 	{#if view === VIEWS.MAGIC_LINK}
 		<MagicLink {i18n} {supabaseClient} bind:authView={view} {appearance} {redirectTo} {showLinks} />


### PR DESCRIPTION
## What kind of change does this PR introduce?

feature

## What is the current behavior?
Previously, it would behave as if the users just logged in.

In my app `PASSWORD_RECOVERY` event doesn't fire after following the password reset link, at least locally. I want to make sure users end up in the right page to set their new password.

You can find a relevant discussion in this issue: https://github.com/supabase/auth-ui/issues/77#issuecomment-1343198673

## What is the new behavior?
This prop allows you to redirect users to a page where they can set their new password.
