### PR TITLE
Fix `sign_up.social_provider_text` label

### DIFF
--- a/packages/shared/src/localization/en.json
+++ b/packages/shared/src/localization/en.json
@@ -6,7 +6,7 @@
     "password_input_placeholder": "Your password",
     "button_label": "Sign up",
     "loading_button_label": "Signing up ...",
-    "social_provider_text": "Sign in with {{provider}}",
+    "social_provider_text": "Sign up with {{provider}}",
     "link_text": "Don't have an account? Sign up",
     "confirmation_text": "Check your email for the confirmation link"
   },


### PR DESCRIPTION
## What kind of change does this PR introduce?
Fix `sign_up.social_provider_text` label.

## What is the current behavior?
`Sign in with {{provider}}`

## What is the new behavior?
`Sign up with {{provider}}`
