### PR TITLE
Update en.json

### DIFF
--- a/packages/shared/src/localization/en.json
+++ b/packages/shared/src/localization/en.json
@@ -6,7 +6,7 @@
     "password_input_placeholder": "Your password",
     "button_label": "Sign up",
     "loading_button_label": "Signing up ...",
-    "social_provider_text": "Sign in with {{provider}}",
+    "social_provider_text": "Sign up with {{provider}}",
     "link_text": "Don't have an account? Sign up",
     "confirmation_text": "Check your email for the confirmation link"
   },


### PR DESCRIPTION
## What kind of change does this PR introduce?
changed the sign_up : {social_provider_text} from "sign in with" to "sign up with"
Bug fix, feature, docs update, ...

## What is the current behavior?
it shouldn't be using the word "sign in" here

Please link any relevant issues here.

## What is the new behavior?
change "sign in" to "sign up"

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
