### PR TITLE
Linkedin OIDC Logo and title in react auth

### DIFF
--- a/packages/react/src/components/Auth/Icons.tsx
+++ b/packages/react/src/components/Auth/Icons.tsx
@@ -22,6 +22,7 @@ export const Icons = ({ provider }: IconsProps) => {
   if (provider == 'azure') return azure()
   if (provider == 'keycloak') return keycloak()
   if (provider == 'linkedin') return linkedin()
+  if (provider == 'linkedin_oidc') return linkedin()
   if (provider == 'notion') return notion()
   if (provider == 'slack') return slack()
   if (provider == 'spotify') return spotify()

--- a/packages/react/src/components/Auth/interfaces/SocialAuth.tsx
+++ b/packages/react/src/components/Auth/interfaces/SocialAuth.tsx
@@ -58,6 +58,13 @@ function SocialAuth({
     setLoading(false)
   }
 
+  function handleProviderNameEdgeCases(provider: string) {
+    if (provider === 'linkedin_oidc') {
+      return 'LinkedIn'
+    }
+    return provider
+  }
+
   function capitalize(word: string) {
     const lower = word.toLowerCase()
     return word.charAt(0).toUpperCase() + lower.slice(1)
@@ -87,7 +94,9 @@ function SocialAuth({
                       template(
                         i18n?.[currentView]?.social_provider_text as string,
                         {
-                          provider: capitalize(provider),
+                          provider: capitalize(
+                            handleProviderNameEdgeCases(provider)
+                          ),
                         }
                       )}
                   </Button>


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adding in the linkedin logo and fixing the display name when using the new LinkedIn  OIDC provider

## What is the current behavior?

Currently it looks like this with the new provider

<img width="388" alt="sign-in" src="https://github.com/supabase/auth-ui/assets/53014897/9632678b-ea87-4ade-b39d-d72e31ac066f">

Which is not ideal

## What is the new behavior?

In the react example it now looks like this running in dev:

<img width="564" alt="Screenshot 2023-11-18 at 17 49 31" src="https://github.com/supabase/auth-ui/assets/53014897/f58556ff-14f0-49e6-86f9-94f85f60081f">

The same way it looks with the old provider

## Additional context

There is an issue filed for this here:

https://github.com/supabase/auth-ui/issues/234

This is my first pull request here, I've tried to follow the guidelines but apologies if I've not stuck to protocol in some way
