### PR TITLE
docs: add notice of movement of Auth UI from Supabase to Supabase-Community

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 
-# Deprecation Notice
+# Maintenance Mode
 
 As of 7th Feb 2024, this repository is no longer maintained by the Supabase Team. At the moment, the team does not have capacity to give the expected level of care to this repository. We may revisit Auth UI in the future but regrettably have to leave it on hold for now as we focus on other priorities such as improving the Auth Helpers and advanced Auth primitives.
 
@@ -7,7 +7,7 @@ The repository itself will continue to exist and we will move bulk of the Auth U
 
 We would like to thank everyone for your contributions to the repository. Please feel free to open an issue if you have any questions or concerns.
 
-Thank you
+Thank you.
 
 # Supabase Auth UI
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+
+# Deprecation Notice
+
+As of 7th Feb 2024, this repository is no longer maintained by the Supabase Team. At the moment, the team does not have capacity to give the expected level of care to this repository. We may revisit Auth UI in the future but regrettably have to leave it on hold for now as we focus on other priorities such as improving the Auth Helpers and advanced Auth primitives.
+
+The repository itself will continue to exist and we will move the Auth UI to [Supabase-Community](https://github.com/supabase-community/auth-ui) over the next few weeks. We will continue to keep the latest packages available at `@supabase/auth-ui-react` namespace.
+
+We would like to thank everyone for your contributions to the repository.
+
+Please open an issue if you have any questions or concerns
+Thank you
+
 # Supabase Auth UI
 
 Supabase Auth UI is a collection of pre built UI components that work seamlessly with @supabase/auth-helpers.

--- a/README.md
+++ b/README.md
@@ -3,11 +3,10 @@
 
 As of 7th Feb 2024, this repository is no longer maintained by the Supabase Team. At the moment, the team does not have capacity to give the expected level of care to this repository. We may revisit Auth UI in the future but regrettably have to leave it on hold for now as we focus on other priorities such as improving the Auth Helpers and advanced Auth primitives.
 
-The repository itself will continue to exist and we will move the Auth UI to [Supabase-Community](https://github.com/supabase-community/auth-ui) over the next few weeks. We will continue to keep the latest packages available at `@supabase/auth-ui-react` namespace.
+The repository itself will continue to exist and we will move bulk of the Auth UI to [Supabase-Community](https://github.com/supabase-community/auth-ui) over the next few weeks. As subset of components within the Next.js ecosystem, such as Forgot Password Pages, will be iterated on. We will continue to keep the latest packages for frameworks available at `@supabase/auth-ui-svelte`.
 
-We would like to thank everyone for your contributions to the repository.
+We would like to thank everyone for your contributions to the repository. Please feel free to open an issue if you have any questions or concerns.
 
-Please open an issue if you have any questions or concerns
 Thank you
 
 # Supabase Auth UI

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 As of 7th Feb 2024, this repository is no longer maintained by the Supabase Team. At the moment, the team does not have capacity to give the expected level of care to this repository. We may revisit Auth UI in the future but regrettably have to leave it on hold for now as we focus on other priorities such as improving the Auth Helpers and advanced Auth primitives.
 
-The repository itself will continue to exist and we will move bulk of the Auth UI to [Supabase-Community](https://github.com/supabase-community/auth-ui) over the next few weeks. As subset of components within the Next.js ecosystem, such as Forgot Password Pages, will be iterated on. We will continue to keep the latest packages for frameworks available at `@supabase/auth-ui-svelte`.
+The repository itself will continue to exist and we will move bulk of the Auth UI to [Supabase-Community](https://github.com/supabase-community/auth-ui) over the next few weeks. A subset of components within the Next.js ecosystem, such as Forgot Password Pages, will be iterated on. We will continue to keep the latest packages for frameworks available at `@supabase/auth-ui-svelte`.
 
 We would like to thank everyone for your contributions to the repository. Please feel free to open an issue if you have any questions or concerns.
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

As per internal discussion, the team does not have the capacity to provide the due care and concern required for this repository. Additionally, our recommended approach to authentication has changed since creation of Auth UI and we will need time to revisit construct

As such, we'll be moving bulk of this repository from Supabase to Supabase-Community and potentially expanding on a few core Templates within the Next.js ecosystem.

For now, please visit the our guides on [Server Side Rendering](https://supabase.com/docs/guides/auth/server-side/overview) and the @supabase/ssr for further details on implementing Auth with Supabase.